### PR TITLE
Consider changing "Real-Time Transit" to "Transit"

### DIFF
--- a/views/categories.jade
+++ b/views/categories.jade
@@ -32,8 +32,8 @@ link(rel='stylesheet', type='text/css', href='/stylesheets/categories.css')
       img.category-icon(src='/images/public_facilities.png', alt='', height='100', width='120')
       h3.definition
         | Municipal public amenities, such as schools or parks and their associated location information
-    .square(value='Real-Time Transit')
-      | Real-Time Transit
+    .square(value='Transit')
+      | Transit
       img.category-icon(src='/images/transit.png', alt='', height='90', width='90')
       h3.definition
         | Municipal or commissioned transit services' real-time information, such as the location of a bus in real-time

--- a/views/categories.jade
+++ b/views/categories.jade
@@ -36,7 +36,7 @@ link(rel='stylesheet', type='text/css', href='/stylesheets/categories.css')
       | Transit
       img.category-icon(src='/images/transit.png', alt='', height='90', width='90')
       h3.definition
-        | Municipal or commissioned transit services' real-time information, such as the location of a bus in real-time
+        | Public transit services' schedule data or real-time location information
     .square(value='Road Construction')
       | Road Construction
       img.category-icon(src='/images/road_construction.png', alt='', height='90', width='90')


### PR DESCRIPTION
"Real-Time Transit" isn't correct, as GTFS (specifically GTFS static, as opposed to GTFS realtime) is not realtime. Might want to just call the category "Transit." Also I made a suggestion for amending the category description.